### PR TITLE
new org and included prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *bin*
+*.jsonl

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,16 +1,12 @@
 package cli
 
 import (
-	"encoding/json"
-	"fmt"
 	"log"
 	"os"
 
 	"github.com/gochaos-app/isaac/cmd"
 	"github.com/urfave/cli/v2"
 )
-
-var config cmd.AWSConfig
 
 func InitCli() {
 	app := &cli.App{
@@ -32,8 +28,7 @@ func InitCli() {
 				Aliases: []string{"c"},
 				Usage:   "Chat with Isaac",
 				Action: func(c *cli.Context) error {
-					isaacCfg := readFile()
-					cmd.ChatGo(isaacCfg)
+					cmd.ChatBedrock()
 					return nil
 				},
 			},
@@ -42,9 +37,8 @@ func InitCli() {
 				Aliases: []string{"p"},
 				Usage:   "make a simple prompt, prompt should be enclosed in quotes",
 				Action: func(c *cli.Context) error {
-					isaacCfg := readFile()
-					cfg := cmd.GetAwsCfg(isaacCfg.Region)
-					cmd.ChatBD(c.Args().First(), isaacCfg.Model, isaacCfg.Tokens, isaacCfg.Temperature, cfg)
+
+					cmd.ChatBD(c.Args().First())
 					return nil
 				},
 			},
@@ -54,26 +48,4 @@ func InitCli() {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func readFile() *cmd.AWSConfig {
-	homeEnv := os.Getenv("HOME")
-	filePath := homeEnv + "/.isaac_config.json"
-	_, error := os.Stat(filePath)
-	if os.IsNotExist(error) {
-		fmt.Println("Config file doesnt exists")
-		fmt.Println("Please run isaac init")
-		os.Exit(1)
-	}
-	// Open our jsonFile
-	jsonFile, err := os.ReadFile(filePath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = json.Unmarshal(jsonFile, &config)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println("Successfully Opened config file")
-	return &config
 }

--- a/cmd/S3.go
+++ b/cmd/S3.go
@@ -2,33 +2,32 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"log"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-func Save2S3(cfg aws.Config, bucket string) {
-
-	fileJsonl, err := os.Open("prompts.jsonl")
+func Save2S3(name string) string {
+	_, _, _, bucket, cfg := GetAwsCfg()
+	if name == "" {
+		name = "prompts.jsonl"
+	}
+	fileJsonl, err := os.Open(name)
 	if err != nil {
-		fmt.Println(err)
-		return
+		return err.Error()
 	}
 
 	defer fileJsonl.Close()
 	svc := s3.NewFromConfig(cfg)
 	_, err = svc.PutObject(context.TODO(), &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
-		Key:    aws.String("prompts.jsonl"),
+		Key:    aws.String(name),
 		Body:   fileJsonl,
 	})
 	if err != nil {
-		fmt.Println(err)
-		return
+		return err.Error()
 	}
-	log.Println("Successfully uploaded to S3", bucket)
+	return "Successfully uploaded to S3 " + bucket
 
 }

--- a/cmd/awsCfg.go
+++ b/cmd/awsCfg.go
@@ -2,19 +2,47 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 
-func GetAwsCfg(region string) aws.Config {
+func ReadInitFile() *AWSConfig {
+	var config AWSConfig
+	homeEnv := os.Getenv("HOME")
+	filePath := homeEnv + "/.isaac_config.json"
+	_, error := os.Stat(filePath)
+	if os.IsNotExist(error) {
+		fmt.Println("Config file doesnt exists")
+		fmt.Println("Please run isaac init")
+		os.Exit(1)
+	}
+	// Open our jsonFile
+	jsonFile, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = json.Unmarshal(jsonFile, &config)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+	return &config
+}
+
+func GetAwsCfg() (string, string, string, string, aws.Config) {
+
+	isaacCfg := ReadInitFile()
+
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(isaacCfg.Region))
 	if err != nil {
 		fmt.Println("Unable to load SDK config, " + err.Error())
 		log.Fatal(err)
 	}
-	return cfg
+
+	return isaacCfg.Model, isaacCfg.Tokens, isaacCfg.Temperature, isaacCfg.S3Bucket, cfg
 }

--- a/cmd/chatBedRock.go
+++ b/cmd/chatBedRock.go
@@ -20,7 +20,9 @@ type Request struct {
 	StopSequences []string `json:"stop_sequences,omitempty"`
 }
 
-func ChatBD(cmdStr, model, tokens, temperature string, cfg aws.Config) string {
+func ChatBD(cmdStr string) string {
+
+	model, tokens, temperature, _, cfg := GetAwsCfg()
 	brc := bedrockruntime.NewFromConfig(cfg)
 	tokensInt, _ := strconv.Atoi(tokens)
 	temperature64, _ := strconv.ParseFloat(temperature, 64)
@@ -33,13 +35,13 @@ func ChatBD(cmdStr, model, tokens, temperature string, cfg aws.Config) string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	modelId := model
+
 	TypeContent := "application/json"
 	AcceptContent := "*/*"
 	output, err := brc.InvokeModel(context.Background(),
 		&bedrockruntime.InvokeModelInput{
 			Body:        payloadJson,
-			ModelId:     aws.String(modelId),
+			ModelId:     aws.String(model),
 			ContentType: aws.String(TypeContent),
 			Accept:      aws.String(AcceptContent),
 		})

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gochaos-app/isaac/ops"
 )
 
-const commandPrompt = "You are an expert in Linux Operating Systems and the task is to provide bash commands. Return ONLY a command. DO NOT put it in a code block, DO NOT USE single or double quotes, or any other character. Give me ONLY the command ready to run in a BASH terminal. The command should do: "
+const commandPrompt = "You are an expert in Linux Operating Systems and the task is to provide bash commands. Return ONLY a command inside a code Block, for example ```ls```. DO NOT USE single or double quotes, or any other character. Give me ONLY the command ready to run in a BASH terminal. The command should do: "
 const kubernetesPrompt = "The main task is to provide instructions for a kubernetes cluster. Return a kubectl command and a brief explanation of the command, Please provide command an explanation for: "
 
 func cmdPromptFn(cmdStr string) string {

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/gochaos-app/isaac/ops"
+)
+
+const commandPrompt = "You are an expert in Linux Operating Systems and the task is to provide bash commands. Return ONLY a command. DO NOT put it in a code block, DO NOT USE single or double quotes, or any other character. Give me ONLY the command ready to run in a BASH terminal. The command should do: "
+const kubernetesPrompt = "The main task is to provide instructions for a kubernetes cluster. Return a kubectl command and a brief explanation of the command, Please provide command an explanation for: "
+
+func cmdPromptFn(cmdStr string) string {
+	complete := commandPrompt + cmdStr
+	response := ChatBD(complete)
+	return response
+}
+
+func k8sPromptFn(cmdStr string) string {
+	complete := kubernetesPrompt + cmdStr
+	response := ChatBD(complete)
+	return response
+}
+
+func filePromptFn(cmdStr string) string {
+	SliceFile := strings.Fields(cmdStr)
+	filename := SliceFile[0]
+	prompt := strings.Join(SliceFile[2:], " ")
+
+	file, err := ops.LoadFile(filename)
+
+	if err != nil {
+		fmt.Println("Error reading file")
+		return ""
+	}
+	complete := prompt + ": " + file
+	response := ChatBD(complete)
+	return response
+}
+
+func executeCommand(cleanCmd string) {
+
+	CmdSlice := strings.Fields(cleanCmd)
+	cmd := exec.Command(CmdSlice[0], CmdSlice[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	fmt.Println(cmd.Run())
+
+}

--- a/cmd/saveDB.go
+++ b/cmd/saveDB.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"log"
 	"os"
 )
 
@@ -11,18 +10,21 @@ type fileDB struct {
 	Completion string `json:"completion"`
 }
 
-func savePrompts(entries []fileDB) {
-	tmpfile, err := os.Create("prompts.jsonl")
+func savePrompts(name string) string {
+	if name == "" {
+		name = "prompts.jsonl"
+	}
+	tmpfile, err := os.Create(name)
 	if err != nil {
-		log.Fatal(err)
+		return err.Error()
 	}
 	defer tmpfile.Close()
 	for _, d := range entries {
 		jsonData, err := json.Marshal(d)
 		if err != nil {
-			log.Fatal(err)
+			return err.Error()
 		}
 		tmpfile.WriteString(string(jsonData) + "\n")
 	}
-
+	return "Prompts saved"
 }

--- a/ops/opsString.go
+++ b/ops/opsString.go
@@ -1,29 +1,33 @@
 package ops
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 )
+
+func FindInst(cmdStr string) []string {
+	split := strings.Split(cmdStr, ":")
+	return split
+}
+
+func FindCmd(IsaacStr, cmdStr string) string {
+	rx := regexp.MustCompile(IsaacStr + `:(.*)`)
+	matches := rx.FindStringSubmatch(cmdStr)
+	if len(matches) > 1 {
+		fmt.Println(matches[1])
+	}
+	return matches[1]
+}
+
+func CleanCmd(cmdStr string) string {
+	rx := regexp.MustCompile(`[^a-zA-Z0-9\s\-_./]`)
+	clean := rx.ReplaceAllString(cmdStr, " ")
+	return clean
+}
 
 func FindSys(cmdStr string) []string {
 	rx := regexp.MustCompile(`(sys\.)(\w+)(?:\(([^)]*)\))?`)
 	matches := rx.FindStringSubmatch(cmdStr)
-	return matches
-}
-
-func FindCmdIgnoreParams(cmdStr string) []string {
-	rx := regexp.MustCompile(`cmd\(([^)]*)\)`)
-	matches := rx.FindStringSubmatch(cmdStr)
-	return matches
-}
-
-func FindLoadIgnoreParams(loadStr string) []string {
-	rx := regexp.MustCompile(`load\(([^)]*)\)`)
-	matches := rx.FindStringSubmatch(loadStr)
-	return matches
-}
-
-func MakeSummaryIgnoreParams(loadStr string) []string {
-	rx := regexp.MustCompile(`summary\(([^)]*)\)`)
-	matches := rx.FindStringSubmatch(loadStr)
 	return matches
 }


### PR DESCRIPTION
New organization on the code, not better but I do think is bit cleaner.
Also included prompts for linux and kubernetes, although right now only the linux commands are able to be executed. 
```bash
@Isaac: command: delete a file, filename is test.txt    

```rm test.txt```

Execute command? Only yes is accepted: 
   
rm test.txt
```

```bash
@Isaac → command: check for user ports    

```netstat -tulpn```
Execute command? Only yes is accepted: 
   netstat -tulpn   
yes
```

This does remove the cmd(ps aux) and load(filename) functionalities previously implemented, seem bit overkill with this new functionality. 
## TODO
Better prompts for kubernetes and perhaps we can include other tools, such as github or maybe terraform.